### PR TITLE
Fix description on extensions list

### DIFF
--- a/i18n/de/ext.php
+++ b/i18n/de/ext.php
@@ -12,6 +12,6 @@ return array(
 		'limit' => 'Anzahl eingelesener Feed-Elemente',
 		'field' => 'Inhalt, der an die KI gesendet wird',
 		'api_timeout' => 'Maximale API Anfragedauer (Sekunden)',
-		'configure_tips' => 'Für `KI Anbieter` und `Modell` können jegliche gültige Werte eingetragen werden, auch wenn sie nicht in der Auswahlliste auftauchen. Gehe sicher, dass diese für deinen KI Anbieter oder [Portkey-AI/gateway](https://portkey.ai/docs/integrations/llms) gültig sind.',
+		'configure_tips' => 'Für <code>KI Anbieter</code> und <code>Modell</code> können jegliche gültige Werte eingetragen werden, auch wenn sie nicht in der Auswahlliste auftauchen. Gehe sicher, dass diese für deinen KI Anbieter oder <a href="https://portkey.ai/docs/integrations/llms">Portkey-AI/gateway</a> gültig sind.',
 	),
 );

--- a/i18n/en/ext.php
+++ b/i18n/en/ext.php
@@ -12,6 +12,6 @@ return array(
 		'limit' => 'Read the number of feeds',
 		'fields' => 'Fields to send to AI',
 		'api_timeout' => 'API request timeout (seconds)',
-		'configure_tips' => 'You could input any valid value for `AI Provider` and `Model` even thought they are not in the select list. But make sure they are supported by your AI Provider or [Portkey-AI/gateway](https://portkey.ai/docs/integrations/llms).',
+		'configure_tips' => 'You could input any valid value for <code>AI Provider</code> and <code>Model</code> even thought they are not in the select list. But make sure they are supported by your AI Provider or <a href="https://portkey.ai/docs/integrations/llms">Portkey-AI/gateway</a>.',
 	),
 );

--- a/i18n/zh-cn/ext.php
+++ b/i18n/zh-cn/ext.php
@@ -12,6 +12,6 @@ return array(
 		'limit' => '一次性读取文章数量',
 		'fields' => '发送给AI的字段',
 		'api_timeout' => 'API 请求超时(秒)',
-		'configure_tips' => '你可以为 `AI供应商` 和 `模型` 输入任何有效值，即使它们不在下拉列表中。但请确保它们受你的AI供应商或 [Portkey-AI/gateway](https://portkey.ai/docs/integrations/llms) 支持。',
+		'configure_tips' => '你可以为 <code>AI供应商</code> 和 <code>模型</code> 输入任何有效值，即使它们不在下拉列表中。但请确保它们受你的AI供应商或 <a href="https://portkey.ai/docs/integrations/llms">Portkey-AI/gateway</a> 支持。',
 	),
 );

--- a/i18n/zh-tw/ext.php
+++ b/i18n/zh-tw/ext.php
@@ -12,6 +12,6 @@ return array(
 		'limit' => '一次性讀取文章數量',
 		'fields' => '發送給AI的字段',
 		'api_timeout' => 'API 請求超時(秒)',
-		'configure_tips' => '你可以為 `AI提供者` 和 `模型` 輸入任何有效值，即使它們不在下拉列表中。但請確保它們受你的AI提供者或 [Portkey-AI/gateway](https://portkey.ai/docs/integrations/llms) 支持。',
+		'configure_tips' => '你可以為 <code>AI提供者</code> 和 <code>模型</code> 輸入任何有效值，即使它們不在下拉列表中。但請確保它們受你的AI提供者或 <a href="https://portkey.ai/docs/integrations/llms">Portkey-AI/gateway</a> 支持。',
 	),
 );

--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,7 @@
 {
 	"name": "News Assistant",
 	"author": "Mervyn Zhan",
-	"description": "Support OpenAI-Compatible API and the other AI api like `Anthropic`, `Groq` by [Portkey-AI/gateway](https://github.com/Portkey-AI/gateway/) to summary the news.",
+	"description": "Support OpenAI-Compatible API and the other AI api like Anthropic, Groq by <a href=\"https://github.com/Portkey-AI/gateway/\">Portkey-AI/gateway</a> to summary the news.",
 	"version": "0.13.1",
 	"entrypoint": "NewsAssistant",
 	"type": "user"


### PR DESCRIPTION
Before

<img width="1514" height="66" src="https://github.com/user-attachments/assets/325b98fa-1a08-466d-b41e-0cfe4acd432e" />

After

<img width="1479" height="45" src="https://github.com/user-attachments/assets/1cd88e26-2868-4da6-b6af-ea639fc823d6" />

FreshRSS allows to embed `<a>` tags inside description, but not markdown


